### PR TITLE
14 feature gsap page loader

### DIFF
--- a/src/components/PageLoader.astro
+++ b/src/components/PageLoader.astro
@@ -32,6 +32,7 @@ const tl = gsap.timeline();
         ease: 'power4.out',   
     },"=0.4");
 
+    // Progressive Enhancement: If GSAP is not loaded, show the loader without animation. https://gsap.com/community/forums/topic/39201-best-practices-for-autoalpha-progressive-enhancement/
     if (typeof window.gsap === "undefined") {
       document.querySelector(".progressive-enhancement").classList.add("js");
     }


### PR DESCRIPTION
### What does this change?

Before loading the website a page loader will appear with our logo. The FAZAEL text will be displayed with a split text and the logo will scale for a couple times.  Therefore I used the GSAP Split text plugin to split the `<h1>`. After that I added a scale effect to the logo.


Related to issue #14

[livesite](https://livesite.com)

### How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()
- [ ] [Keyboard test]()
- [ ] [HTML Validator]()
- [x] [Progressive enhancement test]()

**Progressive enhancement test**
The pageloader will then not be visible when JS is disabled.

https://github.com/user-attachments/assets/9d7c3ac4-9509-4b4f-a80d-a91fe050df79



### Images


https://github.com/user-attachments/assets/160e4200-ea03-4d5f-8cde-36d6c5285cd0



### How to review
- To read the full code go to the PageLoader.astro component. I forgot to make a brach from the beginning my bad!
- For explanation about the code see issue #14 
